### PR TITLE
Major Issues Fixed -- Now works in 4.2+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # I like to store old releases in my project folder for this project.
 releases
+/.github/chatmodes
+/.github/prompts

--- a/MODERNIZATION_CHECKLIST.md
+++ b/MODERNIZATION_CHECKLIST.md
@@ -1,0 +1,385 @@
+# Blender 3MF Format Addon - Modernization Checklist
+
+## 📋 Overview
+This checklist tracks the modernization of the Blender 3MF addon from Blender 2.8 to 4.2+.
+
+**Estimated Time:** 2-3 weeks  
+**Difficulty:** 6/10 (Moderate)
+
+---
+
+## Phase 1: Critical Fixes (Must Complete First) 🔴
+
+### Import/Export Fixes
+- [x] Fix reload logic in `__init__.py`
+- [x] Add copyright notice for 2025 modernization
+- [x] Update README with modernization status
+- [x] Replace wildcard imports with explicit imports in all files
+
+#### Files to Fix:
+- [x] `io_mesh_3mf/import_3mf.py` - Add `conflicting_mustpreserve_contents`
+- [x] `io_mesh_3mf/export_3mf.py` - Replace `from .constants import *`
+- [x] `io_mesh_3mf/annotations.py` - Replace `from .constants import *`
+- [x] `io_mesh_3mf/metadata.py` - Check for any wildcard imports
+
+### Property Syntax Updates (Blender 4.2+ Compatibility)
+- [ ] Fix `export_3mf.py` property annotations
+  - [ ] Remove `: ` from `filter_glob` (line 50)
+  - [ ] Remove `: ` from `use_selection` (line 51)
+  - [ ] Remove `: ` from `global_scale` (line 57)
+  - [ ] Remove `: ` from `use_mesh_modifiers` (line 60)
+  - [ ] Remove `: ` from `coordinate_precision` (line 65)
+
+- [ ] Fix `import_3mf.py` property annotations
+  - [ ] Remove `: ` from `filter_glob`
+  - [ ] Remove `: ` from `files`
+  - [ ] Remove `: ` from `directory`
+  - [ ] Remove `: ` from `global_scale`
+
+### bl_info Updates
+- [ ] Update `bl_info` in `__init__.py`
+  - [ ] Change `"blender": (2, 80, 0)` to `"blender": (4, 2, 0)`
+  - [ ] Update version to `(2, 0, 0)` or similar to indicate major update
+  - [ ] Update `"author"` to include contributor info
+
+---
+
+## Phase 2: Blender 4.2+ API Compatibility Testing 🟡
+
+### Initial Testing
+- [ ] Install addon in Blender 4.2
+- [ ] Test basic loading (does it appear in preferences?)
+- [ ] Document all errors that occur
+
+### Export Testing
+- [ ] Test exporting a simple cube
+  - [ ] Note any errors
+  - [ ] Check if file is created
+- [ ] Test exporting with materials
+  - [ ] Check material color export
+  - [ ] Verify shader node access works
+- [ ] Test exporting with modifiers
+- [ ] Test "Selection Only" option
+- [ ] Test scale settings
+- [ ] Test precision settings
+
+### Import Testing
+- [ ] Test importing `test/resources/only_3dmodel_file.3mf`
+  - [ ] Note any errors
+  - [ ] Verify mesh appears in scene
+- [ ] Test importing file with materials
+- [ ] Test importing file with metadata
+- [ ] Test scale settings
+
+### Material System Fixes (HIGH RISK AREA)
+- [ ] Test `bpy_extras.node_shader_utils.PrincipledBSDFWrapper` compatibility
+  - Location: `export_3mf.py` line ~239
+  - [ ] Verify `base_color` property access works
+  - [ ] Verify `alpha` property access works
+  - [ ] Check if color space conversion is correct
+- [ ] Test material slot access patterns
+- [ ] Verify material index handling
+
+### Mesh API Fixes
+- [ ] Test `mesh.calc_loop_triangles()` (export_3mf.py line ~388)
+- [ ] Test `mesh.loop_triangles` access
+- [ ] Test `blender_object.to_mesh()` (export_3mf.py line ~383)
+- [ ] Test `bpy.context.evaluated_depsgraph_get()` (export_3mf.py line ~376)
+- [ ] Test `blender_object.evaluated_get()` (export_3mf.py line ~377)
+
+### Context Usage Fixes
+- [ ] Replace `bpy.context` with passed `context` parameter in:
+  - [ ] `export_3mf.py` line 116 (`scene_metadata.retrieve(bpy.context.scene)`)
+  - [ ] `export_3mf.py` line 376 (`bpy.context.evaluated_depsgraph_get()`)
+  - [ ] Any other instances found
+
+### Property Storage Fixes
+- [ ] Verify `bpy.data.texts` still works for storing annotations
+  - Location: `annotations.py` `store()` method
+  - Location: `export_3mf.py` `must_preserve()` method
+- [ ] Test `textfile.as_string()` method compatibility
+- [ ] Check if `idprop.types` import is needed (metadata.py line 2)
+
+---
+
+## Phase 3: Test Suite Modernization 🧪
+
+### Unit Tests (Mock-Based)
+- [ ] Fix wildcard imports in test files
+  - [ ] `test/annotations.py` - Replace `from io_mesh_3mf.constants import *`
+  - [ ] `test/export_3mf.py` - Replace `from io_mesh_3mf.constants import *`
+  - [ ] `test/import_3mf.py` - Replace `from io_mesh_3mf.constants import *`
+  - [ ] `test/metadata.py` - Check for wildcards
+
+- [ ] Update mock objects for Blender 4.2 API
+  - [ ] Update `test/mock/bpy.py` if needed
+  - [ ] Verify `PrincipledBSDFWrapper` mock is correct
+
+- [ ] Run existing unit tests
+  - [ ] `python -m unittest discover test`
+  - [ ] Fix any failures
+  - [ ] Document which tests pass/fail
+
+### Integration Tests (Real Blender)
+- [ ] Create `test/run_integration_tests.py`
+  - [ ] Copy structure from review notes
+  - [ ] Add test for simple cube export
+  - [ ] Add test for simple cube import
+  - [ ] Add test for round-trip (import then export)
+  - [ ] Add test for materials
+  - [ ] Add test for Blender 4.2 API compatibility
+
+- [ ] Run integration tests
+  - [ ] `blender --background --python test/run_integration_tests.py -- --verbose`
+  - [ ] Fix any failures
+  - [ ] Document results
+
+- [ ] Test with real 3MF files
+  - [ ] Export from Blender, import into slicer
+  - [ ] Import 3MF from slicer, verify in Blender
+  - [ ] Test with complex models (1000+ triangles)
+
+---
+
+## Phase 4: Code Quality Improvements 📝
+
+### Type Hints (Optional but Recommended)
+- [ ] Add type hints to `export_3mf.py`
+  - [ ] `execute()` method
+  - [ ] `create_archive()` method
+  - [ ] `write_materials()` method
+  - [ ] Other major methods
+
+- [ ] Add type hints to `import_3mf.py`
+  - [ ] `execute()` method
+  - [ ] `read_archive()` method
+  - [ ] `read_materials()` method
+  - [ ] Other major methods
+
+- [ ] Add type hints to `annotations.py`
+- [ ] Add type hints to `metadata.py`
+
+### Error Reporting Improvements
+- [ ] Add `self.report()` calls for user feedback in:
+  - [ ] `export_3mf.py` - Replace `log.error()` with `self.report({'ERROR'}, ...)`
+  - [ ] `import_3mf.py` - Replace `log.error()` with `self.report({'ERROR'}, ...)`
+  - [ ] Add `self.report({'WARNING'}, ...)` for non-critical issues
+  - [ ] Add `self.report({'INFO'}, ...)` for successful operations
+
+### String Formatting
+- [ ] Convert all string concatenation to f-strings
+  - [ ] `export_3mf.py`
+  - [ ] `import_3mf.py`
+  - [ ] `annotations.py`
+  - [ ] `metadata.py`
+
+### Code Documentation
+- [ ] Update outdated comments
+  - [ ] Remove "Python 3.7" references (export_3mf.py line 110)
+  - [ ] Update any Blender 2.8 specific comments
+
+- [ ] Add `__all__` exports to modules
+  - [ ] `__init__.py`
+  - [ ] `export_3mf.py`
+  - [ ] `import_3mf.py`
+  - [ ] `annotations.py`
+  - [ ] `metadata.py`
+  - [ ] `constants.py`
+  - [ ] `unit_conversions.py`
+
+---
+
+## Phase 5: CI/CD and Release 🚀
+
+### GitHub Actions Setup
+- [ ] Create `.github/workflows/test.yml`
+  - [ ] Add unit test job (Python only)
+  - [ ] Add integration test job (with Blender download)
+  - [ ] Test against Blender 4.2 and 4.3
+  - [ ] Add code coverage reporting
+
+### Documentation
+- [ ] Update README.md
+  - [x] Add modernization notice
+  - [x] Update installation instructions
+  - [ ] Add testing instructions
+  - [ ] Update compatibility information
+  - [ ] Add troubleshooting section
+
+- [ ] Create CHANGELOG.md
+  - [ ] Document all API changes
+  - [ ] List breaking changes from v1.x
+  - [ ] Note Blender version compatibility
+
+- [ ] Update inline documentation
+  - [ ] Verify all docstrings are accurate
+  - [ ] Update parameter descriptions if API changed
+
+### Release Preparation
+- [ ] Create release checklist
+  - [ ] All tests pass in Blender 4.2
+  - [ ] All tests pass in Blender 4.3
+  - [ ] Export/import tested with real files
+  - [ ] No linter errors
+  - [ ] Documentation complete
+
+- [ ] Version the release
+  - [ ] Update `bl_info["version"]` to `(2, 0, 0)`
+  - [ ] Create git tag
+  - [ ] Build .zip file
+
+- [ ] Test installation
+  - [ ] Install .zip in fresh Blender 4.2
+  - [ ] Verify all features work
+  - [ ] Test uninstall/reinstall
+
+---
+
+## Testing Matrix 🧪
+
+### Blender Versions to Test
+- [ ] Blender 4.2.0 LTS (primary target)
+- [ ] Blender 4.3.0 (latest stable)
+- [ ] Blender 4.4+ (future compatibility)
+
+### Operating Systems to Test
+- [ ] Windows (primary development)
+- [ ] macOS (if available)
+- [ ] Linux (via CI/CD)
+
+### Test Scenarios
+- [ ] **Simple Geometry**
+  - [ ] Single cube export/import
+  - [ ] Multiple objects
+  - [ ] Nested objects (parent/child)
+
+- [ ] **Materials**
+  - [ ] Single material
+  - [ ] Multiple materials per object
+  - [ ] Transparency/alpha
+  - [ ] Material-less objects
+
+- [ ] **Modifiers**
+  - [ ] Export with modifiers applied
+  - [ ] Export without modifiers
+  - [ ] Complex modifier stacks
+
+- [ ] **Scale/Units**
+  - [ ] Different Blender units (mm, cm, m, inches)
+  - [ ] Custom scale factors
+  - [ ] Very small/large models
+
+- [ ] **Edge Cases**
+  - [ ] Empty scene export
+  - [ ] Very large models (100k+ triangles)
+  - [ ] Objects with no geometry
+  - [ ] Corrupted 3MF import
+  - [ ] Unicode characters in names
+
+---
+
+## Known Issues to Address 📌
+
+### High Priority
+- [ ] Material system may need complete rewrite for Blender 4.2
+- [ ] Shader node access patterns changed in 4.x
+- [ ] Property annotation syntax must be updated
+- [ ] Context access needs cleanup
+
+### Medium Priority
+- [ ] Wildcard imports cause linter issues
+- [ ] Missing type hints make maintenance harder
+- [ ] Error messages don't reach user UI
+- [ ] Outdated comments reference old Python/Blender
+
+### Low Priority
+- [ ] No performance benchmarks
+- [ ] Test coverage not measured
+- [ ] No support for 3MF extensions yet
+
+---
+
+## Quick Start Checklist 🏃
+
+**Complete these in order for fastest results:**
+
+1. [ ] Fix all wildcard imports (30 min)
+2. [ ] Fix all property annotations (15 min)
+3. [ ] Update bl_info version (5 min)
+4. [ ] Try loading in Blender 4.2 (15 min)
+5. [ ] Fix immediate errors found (2-4 hours)
+6. [ ] Test export of simple cube (30 min)
+7. [ ] Test import of test file (30 min)
+8. [ ] Document what works/doesn't work (30 min)
+
+**After first 8 steps, you'll know the scope of remaining work!**
+
+---
+
+## Progress Tracking
+
+### Completion Status
+- Phase 1 (Critical): ⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 0%
+- Phase 2 (API Testing): ⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 0%
+- Phase 3 (Tests): ⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 0%
+- Phase 4 (Quality): ⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 0%
+- Phase 5 (Release): ⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 0%
+
+**Overall Progress: 5%** (3 of 150+ items complete)
+
+---
+
+## Notes and Issues
+
+### Blockers
+- None yet
+
+### Questions
+- None yet
+
+### Decisions Made
+1. Modernizing for Blender 4.2+ only (not maintaining 2.8 compatibility)
+2. Using explicit imports instead of wildcards
+3. Keeping original GPL v2+ license
+4. Offering to contribute back to original author
+
+---
+
+## Resources
+
+### Documentation Links
+- [Blender 4.2 API Docs](https://docs.blender.org/api/4.2/)
+- [Blender Python API Changes](https://wiki.blender.org/wiki/Reference/Release_Notes)
+- [3MF Spec](https://github.com/3MFConsortium/spec_core)
+- [Python Type Hints](https://docs.python.org/3/library/typing.html)
+
+### Testing Commands
+```bash
+# Unit tests (no Blender needed)
+python -m unittest discover test
+
+# Integration tests (requires Blender)
+blender --background --python test/run_integration_tests.py -- --verbose
+
+# Install to Blender
+mkdir -p ~/.config/blender/4.2/scripts/addons/
+cp -r io_mesh_3mf ~/.config/blender/4.2/scripts/addons/
+```
+
+### Helper Scripts
+```bash
+# Find all wildcard imports
+grep -r "from .* import \*" io_mesh_3mf/
+
+# Find all bpy.props with type annotations
+grep -r ": bpy.props" io_mesh_3mf/
+
+# Count TODO items
+grep -r "TODO\|FIXME\|XXX" io_mesh_3mf/ | wc -l
+```
+
+---
+
+**Last Updated:** October 7, 2025  
+**Maintained by:** Jack  
+**Original Author:** Ghostkeeper

--- a/README.md
+++ b/README.md
@@ -4,11 +4,38 @@ This is a Blender add-on that allows importing and exporting 3MF files.
 
 3D Manufacturing Format files (.3mf) are a file format for triangular meshes intended to serve as exchange format for 3D printing applications. They can communicate not only the model, but also the intent and material of a 3D printing job from the CAD software to the CAM software (slicer). In this scenario, Blender serves as the CAD software. To that end, the aim of this add-on is to make Blender a more viable alternative as CAD software for additive manufacturing.
 
+## ⚠️ Modernization Notice (2025)
+
+**This fork is being actively modernized for Blender 4.2+**
+
+The original repository by Ghostkeeper has been inactive since 2023. The addon no longer functions in modern Blender versions (4.2+) due to API changes. This fork contains modernization work to restore compatibility.
+
+**Version Guide:**
+- **Blender 4.2+**: Use this modernized fork (work in progress)
+- **Blender 2.8-3.6**: Use the [original repository](https://github.com/Ghostkeeper/Blender3mfFormat/releases/latest)
+
+**Credits:**
+- **Original Author**: Ghostkeeper (2020-2022)
+- **Modernization**: Jack (2025)
+
+**Note to Original Author**: Should Ghostkeeper return to active development, all modernization work will be contributed back to the original repository. This fork exists solely to keep the addon functional for the community while maintaining the original vision and GPL v2+ license.
+
+### Current Modernization Status
+- [x] Fixed reload logic and imports
+- [ ] Updated for Blender 4.2+ API
+- [ ] Fixed material/shader system compatibility
+- [ ] Updated property annotation syntax
+- [ ] Added integration tests for Blender 4.2+
+- [ ] Verified round-trip import/export functionality
+
 Installation
 ----
-This add-on requires Blender 2.80 or newer. It is tested on version 2.80, 2.83, 2.93 3.0 and 3.3.
+**Modernized Version (Blender 4.2+):** This fork is currently under development. Once stable, installation instructions will be updated.
 
-To install this add-on, currently you need to tell Blender where to find a .zip archive with the add-on inside.
+**Original Version (Blender 2.80-3.6):** Use the [original repository releases](https://github.com/Ghostkeeper/Blender3mfFormat/releases/latest).
+
+### Installation Instructions (when ready)
+To install this add-on, you need to tell Blender where to find a .zip archive with the add-on inside.
 1. Download the latest release from the [releases page](https://github.com/Ghostkeeper/Blender3mfFormat/releases/latest). This is a .zip archive.
 2. In Blender, go to Edit -> Preferences and open the Add-ons tab on the left.
 3. Click on the Install... button at the top. Navigate to the .zip you downloaded.

--- a/io_mesh_3mf/__init__.py
+++ b/io_mesh_3mf/__init__.py
@@ -25,17 +25,6 @@ import bpy.utils  # To (un)register the add-on.
 from .export_3mf import Export3MF  # Exports 3MF files.
 from .import_3mf import Import3MF  # Imports 3MF files.
 
-
-bl_info = {
-    "name": "3MF format",
-    "author": "Ghostkeeper",
-    "version": (1, 0, 2),
-    "blender": (2, 80, 0),
-    "location": "File > Import-Export",
-    "description": "Import-Export 3MF files",
-    "category": "Import-Export",
-}
-
 """
 Import and export 3MF files in Blender.
 """

--- a/io_mesh_3mf/__init__.py
+++ b/io_mesh_3mf/__init__.py
@@ -1,5 +1,6 @@
 # Blender add-on to import and export 3MF files.
 # Copyright (C) 2020 Ghostkeeper
+# Copyright (C) 2025 Jack (modernization for Blender 4.2+)
 # This add-on is free software; you can redistribute it and/or modify it under the terms of the GNU General Public
 # License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later
 # version.
@@ -8,7 +9,22 @@
 # You should have received a copy of the GNU General Public License along with this program; if not, write to the Free
 # Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-# <pep8 compliant>
+# Reload functionality.
+if "bpy" in locals():
+    import importlib
+    from . import import_3mf, export_3mf
+
+    importlib.reload(import_3mf)
+    importlib.reload(export_3mf)
+else:
+    from . import import_3mf, export_3mf
+
+import bpy.types  # To (un)register the add-on as an import/export function.
+import bpy.utils  # To (un)register the add-on.
+
+from .export_3mf import Export3MF  # Exports 3MF files.
+from .import_3mf import Import3MF  # Imports 3MF files.
+
 
 bl_info = {
     "name": "3MF format",
@@ -17,26 +33,12 @@ bl_info = {
     "blender": (2, 80, 0),
     "location": "File > Import-Export",
     "description": "Import-Export 3MF files",
-    "category": "Import-Export"
+    "category": "Import-Export",
 }
 
 """
 Import and export 3MF files in Blender.
 """
-
-# Reload functionality.
-if "bpy" in locals():
-    import importlib
-    if "import_3mf" in locals():
-        importlib.reload(import_3mf)
-    if "export_3mf" in locals():
-        importlib.reload(export_3mf)
-
-import bpy.utils  # To (un)register the add-on.
-import bpy.types  # To (un)register the add-on as an import/export function.
-
-from .import_3mf import Import3MF  # Imports 3MF files.
-from .export_3mf import Export3MF  # Exports 3MF files.
 
 
 def menu_import(self, _):
@@ -53,10 +55,7 @@ def menu_export(self, _):
     self.layout.operator(Export3MF.bl_idname, text="3D Manufacturing Format (.3mf)")
 
 
-classes = (
-    Import3MF,
-    Export3MF
-)
+classes = (Import3MF, Export3MF)
 
 
 def register():

--- a/io_mesh_3mf/blender_manifest.toml
+++ b/io_mesh_3mf/blender_manifest.toml
@@ -1,0 +1,23 @@
+schema_version = "1.0.0"
+
+id = "ThreeMF_format"
+version = "1.0.3"
+name = "3MF format"
+tagline = "Import and export 3D Manufacturing Format (3MF) files"
+author = "Ghostkeeper"
+maintainer = "Clonephaze"
+
+type = "add-on"
+
+website = "https://github.com/Ghostkeeper/Blender3mfFormat"
+blender_version_min = "4.2.0"
+license = [
+  "SPDX:GPL-3.0-or-later",
+]
+copyright = [
+  "2025 Clonephaze",
+  "2020 Ghostkeeper",
+]
+
+[permissions]
+    "files" = "For import and export of 3MF files"

--- a/io_mesh_3mf/constants.py
+++ b/io_mesh_3mf/constants.py
@@ -1,5 +1,6 @@
 # Blender add-on to import and export 3MF files.
 # Copyright (C) 2020 Ghostkeeper
+# Copyright (C) 2025 Jack (modernization for Blender 4.2+)
 # This add-on is free software; you can redistribute it and/or modify it under the terms of the GNU General Public
 # License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later
 # version.
@@ -7,8 +8,6 @@
 # warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 # You should have received a copy of the GNU General Public License along with this program; if not, write to the Free
 # Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-
-# <pep8 compliant>
 
 """
 This module defines some constants for 3MF's file structure.

--- a/io_mesh_3mf/export_3mf.py
+++ b/io_mesh_3mf/export_3mf.py
@@ -75,18 +75,6 @@ class Export3MF(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
         max=12,
     )
 
-    def __init__(self):
-        """
-        Initialize some fields with defaults before starting.
-        """
-        super().__init__()
-        self.next_resource_id = 1  # Which resource ID to generate for the next object.
-        self.num_written = 0  # How many objects we've written to the file.
-        self.material_resource_id = (
-            -1
-        )  # We write one material. This is the resource ID of that material.
-        self.material_name_to_index = {}  # For each material in Blender, the index in the 3MF materials group.
-
     def execute(self, context):
         """
         The main routine that writes the 3MF archive.

--- a/io_mesh_3mf/export_3mf.py
+++ b/io_mesh_3mf/export_3mf.py
@@ -1,5 +1,32 @@
+import base64  # To decode files that must be preserved.
+import collections  # Counter, to find the most common material of an object.
+import itertools
+import logging  # To debug and log progress.
+import xml.etree.ElementTree  # To write XML documents with the 3D model data.
+import zipfile  # To write zip archives, the shell of the 3MF file.
+
+import bpy  # The Blender API.
+import bpy.props  # To define metadata properties for the operator.
+import bpy.types  # This class is an operator in Blender, and to find meshes in the scene.
+import bpy_extras.io_utils  # Helper functions to export meshes more easily.
+import bpy_extras.node_shader_utils  # Converting material colors to sRGB.
+import mathutils  # For the transformation matrices.
+
+from .annotations import Annotations  # To store file annotations
+from .constants import (
+    MODEL_LOCATION,
+    MODEL_NAMESPACE,
+    MODEL_DEFAULT_UNIT,
+    conflicting_mustpreserve_contents,
+)
+from .metadata import (
+    Metadata,  # To store metadata from the Blender scene into the 3MF file.
+)
+from .unit_conversions import blender_to_metre, threemf_to_metre
+
 # Blender add-on to import and export 3MF files.
 # Copyright (C) 2020 Ghostkeeper
+# Copyright (C) 2025 Jack (modernization for Blender 4.2+)
 # This add-on is free software; you can redistribute it and/or modify it under the terms of the GNU General Public
 # License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later
 # version.
@@ -10,23 +37,6 @@
 
 # <pep8 compliant>
 
-import base64  # To decode files that must be preserved.
-import bpy  # The Blender API.
-import bpy.props  # To define metadata properties for the operator.
-import bpy.types  # This class is an operator in Blender, and to find meshes in the scene.
-import bpy_extras.io_utils  # Helper functions to export meshes more easily.
-import bpy_extras.node_shader_utils  # Converting material colors to sRGB.
-import collections  # Counter, to find the most common material of an object.
-import itertools
-import logging  # To debug and log progress.
-import mathutils  # For the transformation matrices.
-import xml.etree.ElementTree  # To write XML documents with the 3D model data.
-import zipfile  # To write zip archives, the shell of the 3MF file.
-
-from .annotations import Annotations  # To store file annotations
-from .constants import *
-from .metadata import Metadata  # To store metadata from the Blender scene into the 3MF file.
-from .unit_conversions import blender_to_metre, threemf_to_metre
 
 log = logging.getLogger(__name__)
 
@@ -43,30 +53,27 @@ class Export3MF(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
     filename_ext = ".3mf"
 
     # Options for the user.
-    filter_glob: bpy.props.StringProperty(
-        default="*.3mf",
-        options={'HIDDEN'})
+    filter_glob: bpy.props.StringProperty(default="*.3mf", options={"HIDDEN"})
     use_selection: bpy.props.BoolProperty(
         name="Selection Only",
         description="Export selected objects only.",
-        default=False)
+        default=False,
+    )
     global_scale: bpy.props.FloatProperty(
-        name="Scale",
-        default=1.0,
-        soft_min=0.001,
-        soft_max=1000.0,
-        min=1e-6,
-        max=1e6)
+        name="Scale", default=1.0, soft_min=0.001, soft_max=1000.0, min=1e-6, max=1e6
+    )
     use_mesh_modifiers: bpy.props.BoolProperty(
         name="Apply Modifiers",
         description="Apply the modifiers before saving.",
-        default=True)
+        default=True,
+    )
     coordinate_precision: bpy.props.IntProperty(
         name="Precision",
         description="The number of decimal digits to use in coordinates in the file.",
         default=4,
         min=0,
-        max=12)
+        max=12,
+    )
 
     def __init__(self):
         """
@@ -75,7 +82,9 @@ class Export3MF(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
         super().__init__()
         self.next_resource_id = 1  # Which resource ID to generate for the next object.
         self.num_written = 0  # How many objects we've written to the file.
-        self.material_resource_id = -1  # We write one material. This is the resource ID of that material.
+        self.material_resource_id = (
+            -1
+        )  # We write one material. This is the resource ID of that material.
         self.material_name_to_index = {}  # For each material in Blender, the index in the 3MF materials group.
 
     def execute(self, context):
@@ -93,7 +102,7 @@ class Export3MF(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
 
         archive = self.create_archive(self.filepath)
         if archive is None:
-            return {'CANCELLED'}
+            return {"CANCELLED"}
 
         if self.use_selection:
             blender_objects = context.selected_objects
@@ -111,21 +120,30 @@ class Export3MF(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
         scene_metadata.retrieve(bpy.context.scene)
         self.write_metadata(root, scene_metadata)
 
-        resources_element = xml.etree.ElementTree.SubElement(root, f"{{{MODEL_NAMESPACE}}}resources")
-        self.material_name_to_index = self.write_materials(resources_element, blender_objects)
+        resources_element = xml.etree.ElementTree.SubElement(
+            root, f"{{{MODEL_NAMESPACE}}}resources"
+        )
+        self.material_name_to_index = self.write_materials(
+            resources_element, blender_objects
+        )
         self.write_objects(root, resources_element, blender_objects, global_scale)
 
         document = xml.etree.ElementTree.ElementTree(root)
-        with archive.open(MODEL_LOCATION, 'w', force_zip64=True) as f:
-            document.write(f, xml_declaration=True, encoding='UTF-8', default_namespace=MODEL_NAMESPACE)
+        with archive.open(MODEL_LOCATION, "w", force_zip64=True) as f:
+            document.write(
+                f,
+                xml_declaration=True,
+                encoding="UTF-8",
+                default_namespace=MODEL_NAMESPACE,
+            )
         try:
             archive.close()
         except EnvironmentError as e:
             log.error(f"Unable to complete writing to 3MF archive: {e}")
-            return {'CANCELLED'}
+            return {"CANCELLED"}
 
         log.info(f"Exported {self.num_written} objects to 3MF archive {self.filepath}.")
-        return {'FINISHED'}
+        return {"FINISHED"}
 
     # The rest of the functions are in order of when they are called.
 
@@ -138,7 +156,9 @@ class Export3MF(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
         :return: A zip archive that other functions can add things to.
         """
         try:
-            archive = zipfile.ZipFile(filepath, 'w', compression=zipfile.ZIP_DEFLATED, compresslevel=9)
+            archive = zipfile.ZipFile(
+                filepath, "w", compression=zipfile.ZIP_DEFLATED, compresslevel=9
+            )
 
             # Store the file annotations we got from imported 3MF files, and store them in the archive.
             annotations = Annotations()
@@ -167,8 +187,8 @@ class Export3MF(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
             if contents == conflicting_mustpreserve_contents:
                 continue  # This file was in conflict. Don't preserve any copy of it then.
             contents = base64.b85decode(contents.encode("UTF-8"))
-            filename = filename[len(".3mf_preserved/"):]
-            with archive.open(filename, 'w') as f:
+            filename = filename[len(".3mf_preserved/") :]
+            with archive.open(filename, "w") as f:
                 f.write(contents)
 
     def unit_scale(self, context):
@@ -182,7 +202,9 @@ class Export3MF(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
         scale = self.global_scale
 
         if context.scene.unit_settings.scale_length != 0:
-            scale *= context.scene.unit_settings.scale_length  # Apply the global scale of the units in Blender.
+            scale *= (
+                context.scene.unit_settings.scale_length
+            )  # Apply the global scale of the units in Blender.
 
         threemf_unit = MODEL_DEFAULT_UNIT
         blender_unit = context.scene.unit_settings.length_unit
@@ -218,11 +240,15 @@ class Export3MF(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
                 material = material_slot.material
 
                 material_name = material.name
-                if material_name in name_to_index:  # Already have this material through another object.
+                if (
+                    material_name in name_to_index
+                ):  # Already have this material through another object.
                     continue
 
                 # Wrap this material into a principled render node, to convert its color to sRGB.
-                principled = bpy_extras.node_shader_utils.PrincipledBSDFWrapper(material, is_readonly=True)
+                principled = bpy_extras.node_shader_utils.PrincipledBSDFWrapper(
+                    material, is_readonly=True
+                )
                 color = principled.base_color
                 red = min(255, round(color[0] * 255))
                 green = min(255, round(color[1] * 255))
@@ -239,13 +265,17 @@ class Export3MF(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
                     self.next_resource_id += 1
                     basematerials_element = xml.etree.ElementTree.SubElement(
                         resources_element,
-                        f"{{{MODEL_NAMESPACE}}}basematerials", attrib={
-                            f"{{{MODEL_NAMESPACE}}}id": self.material_resource_id
-                        })
-                xml.etree.ElementTree.SubElement(basematerials_element, f"{{{MODEL_NAMESPACE}}}base", attrib={
-                    f"{{{MODEL_NAMESPACE}}}name": material_name,
-                    f"{{{MODEL_NAMESPACE}}}displaycolor": color_hex
-                })
+                        f"{{{MODEL_NAMESPACE}}}basematerials",
+                        attrib={f"{{{MODEL_NAMESPACE}}}id": self.material_resource_id},
+                    )
+                xml.etree.ElementTree.SubElement(
+                    basematerials_element,
+                    f"{{{MODEL_NAMESPACE}}}base",
+                    attrib={
+                        f"{{{MODEL_NAMESPACE}}}name": material_name,
+                        f"{{{MODEL_NAMESPACE}}}displaycolor": color_hex,
+                    },
+                )
                 name_to_index[material_name] = next_index
                 next_index += 1
 
@@ -261,32 +291,41 @@ class Export3MF(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
         """
         transformation = mathutils.Matrix.Scale(global_scale, 4)
 
-        build_element = xml.etree.ElementTree.SubElement(root, f"{{{MODEL_NAMESPACE}}}build")
+        build_element = xml.etree.ElementTree.SubElement(
+            root, f"{{{MODEL_NAMESPACE}}}build"
+        )
         for blender_object in blender_objects:
             if blender_object.parent is not None:
                 continue  # Only write objects that have no parent, since we'll get the child objects recursively.
-            if blender_object.type not in {'MESH', 'EMPTY'}:
+            if blender_object.type not in {"MESH", "EMPTY"}:
                 continue
 
-            objectid, mesh_transformation = self.write_object_resource(resources_element, blender_object)
+            objectid, mesh_transformation = self.write_object_resource(
+                resources_element, blender_object
+            )
 
-            item_element = xml.etree.ElementTree.SubElement(build_element, f"{{{MODEL_NAMESPACE}}}item")
+            item_element = xml.etree.ElementTree.SubElement(
+                build_element, f"{{{MODEL_NAMESPACE}}}item"
+            )
             self.num_written += 1
             item_element.attrib[f"{{{MODEL_NAMESPACE}}}objectid"] = str(objectid)
             mesh_transformation = transformation @ mesh_transformation
             if mesh_transformation != mathutils.Matrix.Identity(4):
-                item_element.attrib[f"{{{MODEL_NAMESPACE}}}transform"] =\
+                item_element.attrib[f"{{{MODEL_NAMESPACE}}}transform"] = (
                     self.format_transformation(mesh_transformation)
+                )
 
             metadata = Metadata()
             metadata.retrieve(blender_object)
             if "3mf:partnumber" in metadata:
-                item_element.attrib[f"{{{MODEL_NAMESPACE}}}partnumber"] = metadata["3mf:partnumber"].value
+                item_element.attrib[f"{{{MODEL_NAMESPACE}}}partnumber"] = metadata[
+                    "3mf:partnumber"
+                ].value
                 del metadata["3mf:partnumber"]
             if metadata:
                 metadatagroup_element = xml.etree.ElementTree.SubElement(
-                    item_element,
-                    f"{{{MODEL_NAMESPACE}}}metadatagroup")
+                    item_element, f"{{{MODEL_NAMESPACE}}}metadatagroup"
+                )
                 self.write_metadata(metadatagroup_element, metadata)
 
     def write_object_resource(self, resources_element, blender_object):
@@ -304,7 +343,9 @@ class Export3MF(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
         """
         new_resource_id = self.next_resource_id
         self.next_resource_id += 1
-        object_element = xml.etree.ElementTree.SubElement(resources_element, f"{{{MODEL_NAMESPACE}}}object")
+        object_element = xml.etree.ElementTree.SubElement(
+            resources_element, f"{{{MODEL_NAMESPACE}}}object"
+        )
         object_element.attrib[f"{{{MODEL_NAMESPACE}}}id"] = str(new_resource_id)
 
         metadata = Metadata()
@@ -315,31 +356,40 @@ class Export3MF(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
                 object_element.attrib[f"{{{MODEL_NAMESPACE}}}type"] = object_type
             del metadata["3mf:object_type"]
 
-        if blender_object.mode == 'EDIT':
+        if blender_object.mode == "EDIT":
             blender_object.update_from_editmode()  # Apply recent changes made to the model.
         mesh_transformation = blender_object.matrix_world
 
         child_objects = blender_object.children
-        if child_objects:  # Only write the <components> tag if there are actually components.
+        if (
+            child_objects
+        ):  # Only write the <components> tag if there are actually components.
             components_element = xml.etree.ElementTree.SubElement(
-                object_element,
-                f"{{{MODEL_NAMESPACE}}}components")
+                object_element, f"{{{MODEL_NAMESPACE}}}components"
+            )
             for child in blender_object.children:
-                if child.type != 'MESH':
+                if child.type != "MESH":
                     continue
                 # Recursively write children to the resources.
-                child_id, child_transformation = self.write_object_resource(resources_element, child)
+                child_id, child_transformation = self.write_object_resource(
+                    resources_element, child
+                )
                 # Use pseudo-inverse for safety, but the epsilon then doesn't matter since it'll get multiplied by 0
                 # later anyway then.
-                child_transformation = mesh_transformation.inverted_safe() @ child_transformation
+                child_transformation = (
+                    mesh_transformation.inverted_safe() @ child_transformation
+                )
                 component_element = xml.etree.ElementTree.SubElement(
-                    components_element,
-                    f"{{{MODEL_NAMESPACE}}}component")
+                    components_element, f"{{{MODEL_NAMESPACE}}}component"
+                )
                 self.num_written += 1
-                component_element.attrib[f"{{{MODEL_NAMESPACE}}}objectid"] = str(child_id)
+                component_element.attrib[f"{{{MODEL_NAMESPACE}}}objectid"] = str(
+                    child_id
+                )
                 if child_transformation != mathutils.Matrix.Identity(4):
-                    component_element.attrib[f"{{{MODEL_NAMESPACE}}}transform"] =\
+                    component_element.attrib[f"{{{MODEL_NAMESPACE}}}transform"] = (
                         self.format_transformation(child_transformation)
+                    )
 
         # In the tail recursion, get the vertex data.
         # This is necessary because we may need to apply the mesh modifiers, which causes these objects to lose their
@@ -350,7 +400,9 @@ class Export3MF(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
 
         try:
             mesh = blender_object.to_mesh()
-        except RuntimeError:  # Object.to_mesh() is not guaranteed to return Optional[Mesh], apparently.
+        except (
+            RuntimeError
+        ):  # Object.to_mesh() is not guaranteed to return Optional[Mesh], apparently.
             return new_resource_id, mesh_transformation
         if mesh is None:
             return new_resource_id, mesh_transformation
@@ -365,20 +417,26 @@ class Export3MF(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
                 mesh_id = self.next_resource_id
                 self.next_resource_id += 1
                 mesh_object_element = xml.etree.ElementTree.SubElement(
-                    resources_element,
-                    f"{{{MODEL_NAMESPACE}}}object")
+                    resources_element, f"{{{MODEL_NAMESPACE}}}object"
+                )
                 mesh_object_element.attrib[f"{{{MODEL_NAMESPACE}}}id"] = str(mesh_id)
                 component_element = xml.etree.ElementTree.SubElement(
-                    components_element,
-                    f"{{{MODEL_NAMESPACE}}}component")
+                    components_element, f"{{{MODEL_NAMESPACE}}}component"
+                )
                 self.num_written += 1
-                component_element.attrib[f"{{{MODEL_NAMESPACE}}}objectid"] = str(mesh_id)
+                component_element.attrib[f"{{{MODEL_NAMESPACE}}}objectid"] = str(
+                    mesh_id
+                )
             else:  # No components, then we can write directly into this object resource.
                 mesh_object_element = object_element
-            mesh_element = xml.etree.ElementTree.SubElement(mesh_object_element, f"{{{MODEL_NAMESPACE}}}mesh")
+            mesh_element = xml.etree.ElementTree.SubElement(
+                mesh_object_element, f"{{{MODEL_NAMESPACE}}}mesh"
+            )
 
             # Find the most common material for this mesh, for maximum compression.
-            material_indices = [triangle.material_index for triangle in mesh.loop_triangles]
+            material_indices = [
+                triangle.material_index for triangle in mesh.loop_triangles
+            ]
             # If there are no triangles, we provide 0 as index, but it'll not get read by write_triangles either then.
             most_common_material_list_index = 0
 
@@ -387,25 +445,35 @@ class Export3MF(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
                 # most_common_material_object_index is an index from the MeshLoopTriangle, referring to the list of
                 # materials attached to the Blender object.
                 most_common_material_object_index = counter.most_common(1)[0][0]
-                most_common_material = blender_object.material_slots[most_common_material_object_index].material
+                most_common_material = blender_object.material_slots[
+                    most_common_material_object_index
+                ].material
                 # most_common_material_list_index is an index referring to our own list of materials that we put in the
                 # resources.
-                most_common_material_list_index = self.material_name_to_index[most_common_material.name]
+                most_common_material_list_index = self.material_name_to_index[
+                    most_common_material.name
+                ]
                 # We always only write one group of materials. The resource ID was determined when it was written.
-                object_element.attrib[f"{{{MODEL_NAMESPACE}}}pid"] = str(self.material_resource_id)
-                object_element.attrib[f"{{{MODEL_NAMESPACE}}}pindex"] = str(most_common_material_list_index)
+                object_element.attrib[f"{{{MODEL_NAMESPACE}}}pid"] = str(
+                    self.material_resource_id
+                )
+                object_element.attrib[f"{{{MODEL_NAMESPACE}}}pindex"] = str(
+                    most_common_material_list_index
+                )
 
             self.write_vertices(mesh_element, mesh.vertices)
             self.write_triangles(
                 mesh_element,
                 mesh.loop_triangles,
                 most_common_material_list_index,
-                blender_object.material_slots)
+                blender_object.material_slots,
+            )
 
             # If the object has metadata, write that to a metadata object.
             if "3mf:partnumber" in metadata:
-                mesh_object_element.attrib[f"{{{MODEL_NAMESPACE}}}partnumber"] =\
+                mesh_object_element.attrib[f"{{{MODEL_NAMESPACE}}}partnumber"] = (
                     metadata["3mf:partnumber"].value
+                )
                 del metadata["3mf:partnumber"]
             if "3mf:object_type" in metadata:
                 object_type = metadata["3mf:object_type"].value
@@ -413,12 +481,14 @@ class Export3MF(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
                     # Only write if not the default.
                     # Don't write "other" object types since we're not allowed to refer to them. Pretend they are normal
                     # models.
-                    mesh_object_element.attrib[f"{{{MODEL_NAMESPACE}}}type"] = object_type
+                    mesh_object_element.attrib[f"{{{MODEL_NAMESPACE}}}type"] = (
+                        object_type
+                    )
                 del metadata["3mf:object_type"]
             if metadata:
                 metadatagroup_element = xml.etree.ElementTree.SubElement(
-                    object_element,
-                    f"{{{MODEL_NAMESPACE}}}metadatagroup")
+                    object_element, f"{{{MODEL_NAMESPACE}}}metadatagroup"
+                )
                 self.write_metadata(metadatagroup_element, metadata)
 
         return new_resource_id, mesh_transformation
@@ -430,12 +500,16 @@ class Export3MF(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
         :param metadata: The collection of metadata to write to that node.
         """
         for metadata_entry in metadata.values():
-            metadata_node = xml.etree.ElementTree.SubElement(node, f"{{{MODEL_NAMESPACE}}}metadata")
+            metadata_node = xml.etree.ElementTree.SubElement(
+                node, f"{{{MODEL_NAMESPACE}}}metadata"
+            )
             metadata_node.attrib[f"{{{MODEL_NAMESPACE}}}name"] = metadata_entry.name
             if metadata_entry.preserve:
                 metadata_node.attrib[f"{{{MODEL_NAMESPACE}}}preserve"] = "1"
             if metadata_entry.datatype:
-                metadata_node.attrib[f"{{{MODEL_NAMESPACE}}}type"] = metadata_entry.datatype
+                metadata_node.attrib[f"{{{MODEL_NAMESPACE}}}type"] = (
+                    metadata_entry.datatype
+                )
             metadata_node.text = metadata_entry.value
 
     def format_transformation(self, transformation):
@@ -446,7 +520,9 @@ class Export3MF(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
         :param transformation: The transformation matrix to format.
         :return: A serialisation of the transformation matrix.
         """
-        pieces = (row[:3] for row in transformation.transposed())  # Don't convert the 4th column.
+        pieces = (
+            row[:3] for row in transformation.transposed()
+        )  # Don't convert the 4th column.
         result = ""
         for cell in itertools.chain.from_iterable(pieces):
             if result != "":  # First loop, don't put a space in.
@@ -462,7 +538,9 @@ class Export3MF(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
         :param mesh_element: The <mesh> element of the 3MF document.
         :param vertices: A list of Blender vertices to add.
         """
-        vertices_element = xml.etree.ElementTree.SubElement(mesh_element, f"{{{MODEL_NAMESPACE}}}vertices")
+        vertices_element = xml.etree.ElementTree.SubElement(
+            mesh_element, f"{{{MODEL_NAMESPACE}}}vertices"
+        )
 
         # Precompute some names for better performance.
         vertex_name = f"{{{MODEL_NAMESPACE}}}vertex"
@@ -471,12 +549,22 @@ class Export3MF(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
         z_name = f"{{{MODEL_NAMESPACE}}}z"
 
         for vertex in vertices:  # Create the <vertex> elements.
-            vertex_element = xml.etree.ElementTree.SubElement(vertices_element, vertex_name)
-            vertex_element.attrib[x_name] = self.format_number(vertex.co[0], self.coordinate_precision)
-            vertex_element.attrib[y_name] = self.format_number(vertex.co[1], self.coordinate_precision)
-            vertex_element.attrib[z_name] = self.format_number(vertex.co[2], self.coordinate_precision)
+            vertex_element = xml.etree.ElementTree.SubElement(
+                vertices_element, vertex_name
+            )
+            vertex_element.attrib[x_name] = self.format_number(
+                vertex.co[0], self.coordinate_precision
+            )
+            vertex_element.attrib[y_name] = self.format_number(
+                vertex.co[1], self.coordinate_precision
+            )
+            vertex_element.attrib[z_name] = self.format_number(
+                vertex.co[2], self.coordinate_precision
+            )
 
-    def write_triangles(self, mesh_element, triangles, object_material_list_index, material_slots):
+    def write_triangles(
+        self, mesh_element, triangles, object_material_list_index, material_slots
+    ):
         """
         Writes a list of triangles into the specified mesh element.
 
@@ -488,7 +576,9 @@ class Export3MF(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
         :param material_slots: List of materials belonging to the object for which we write triangles. These are
         necessary to interpret the material indices stored in the MeshLoopTriangles.
         """
-        triangles_element = xml.etree.ElementTree.SubElement(mesh_element, f"{{{MODEL_NAMESPACE}}}triangles")
+        triangles_element = xml.etree.ElementTree.SubElement(
+            mesh_element, f"{{{MODEL_NAMESPACE}}}triangles"
+        )
 
         # Precompute some names for better performance.
         triangle_name = f"{{{MODEL_NAMESPACE}}}triangle"
@@ -498,14 +588,18 @@ class Export3MF(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
         p1_name = f"{{{MODEL_NAMESPACE}}}p1"
 
         for triangle in triangles:
-            triangle_element = xml.etree.ElementTree.SubElement(triangles_element, triangle_name)
+            triangle_element = xml.etree.ElementTree.SubElement(
+                triangles_element, triangle_name
+            )
             triangle_element.attrib[v1_name] = str(triangle.vertices[0])
             triangle_element.attrib[v2_name] = str(triangle.vertices[1])
             triangle_element.attrib[v3_name] = str(triangle.vertices[2])
 
             if triangle.material_index < len(material_slots):
                 # Convert to index in our global list.
-                material_index = self.material_name_to_index[material_slots[triangle.material_index].material.name]
+                material_index = self.material_name_to_index[
+                    material_slots[triangle.material_index].material.name
+                ]
                 if material_index != object_material_list_index:
                     # Not equal to the index that our parent object was written with, so we must override it here.
                     triangle_element.attrib[p1_name] = str(material_index)
@@ -520,7 +614,9 @@ class Export3MF(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
         :param decimals: The maximum number of places after the radix to write.
         :return: A string representing that number.
         """
-        formatted = ("{:." + str(decimals) + "f}").format(number).rstrip("0").rstrip(".")
+        formatted = (
+            ("{:." + str(decimals) + "f}").format(number).rstrip("0").rstrip(".")
+        )
         if formatted == "":
             return "0"
         return formatted

--- a/io_mesh_3mf/import_3mf.py
+++ b/io_mesh_3mf/import_3mf.py
@@ -79,21 +79,6 @@ class Import3MF(bpy.types.Operator, bpy_extras.io_utils.ImportHelper):
         name="Scale", default=1.0, soft_min=0.001, soft_max=1000.0, min=1e-6, max=1e6
     )
 
-    def __init__(self):
-        """
-        Initializes the importer with empty fields.
-        """
-        super().__init__()
-        self.resource_objects = {}  # Dictionary mapping resource IDs to ResourceObjects.
-
-        # Dictionary mapping resource IDs to dictionaries mapping indexes to ResourceMaterial objects.
-        self.resource_materials = {}
-
-        # Which of our resource materials already exists in the Blender scene as a Blender material.
-        self.resource_to_material = {}
-
-        self.num_loaded = 0
-
     def execute(self, context):
         """
         The main routine that reads out the 3MF file.

--- a/io_mesh_3mf/import_3mf.py
+++ b/io_mesh_3mf/import_3mf.py
@@ -1,5 +1,6 @@
 # Blender add-on to import and export 3MF files.
 # Copyright (C) 2020 Ghostkeeper
+# Copyright (C) 2025 Jack (modernization for Blender 4.2+)
 # This add-on is free software; you can redistribute it and/or modify it under the terms of the GNU General Public
 # License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later
 # version.
@@ -8,36 +9,50 @@
 # You should have received a copy of the GNU General Public License along with this program; if not, write to the Free
 # Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-# <pep8 compliant>
 
 import base64  # To encode MustPreserve files in the Blender scene.
+import collections  # For namedtuple.
+import logging  # To debug and log progress.
+import os.path  # To take file paths relative to the selected directory.
+import re  # To find files in the archive based on the content types.
+import xml.etree.ElementTree  # To parse the 3dmodel.model file.
+import zipfile  # To read the 3MF files which are secretly zip archives.
+
 import bpy  # The Blender API.
 import bpy.ops  # To adjust the camera to fit models.
 import bpy.props  # To define metadata properties for the operator.
 import bpy.types  # This class is an operator in Blender.
 import bpy_extras.io_utils  # Helper functions to import meshes more easily.
 import bpy_extras.node_shader_utils  # Getting correct color spaces for materials.
-import logging  # To debug and log progress.
-import collections  # For namedtuple.
 import mathutils  # For the transformation matrices.
-import os.path  # To take file paths relative to the selected directory.
-import re  # To find files in the archive based on the content types.
-import xml.etree.ElementTree  # To parse the 3dmodel.model file.
-import zipfile  # To read the 3MF files which are secretly zip archives.
 
-from .annotations import Annotations, ContentType, Relationship  # To use annotations to decide on what to import.
-from .constants import *
-from .metadata import MetadataEntry, Metadata  # To store and serialize metadata.
-from .unit_conversions import blender_to_metre, threemf_to_metre  # To convert to Blender's units.
+from .annotations import (  # To use annotations to decide on what to import.
+    Annotations,
+    ContentType,
+    Relationship,
+)
+from .constants import (
+    RELS_MIMETYPE,
+    MODEL_MIMETYPE,
+    MODEL_NAMESPACES,
+    MODEL_DEFAULT_UNIT,
+    SUPPORTED_EXTENSIONS,
+    CONTENT_TYPES_LOCATION,
+    conflicting_mustpreserve_contents,
+)
+from .metadata import Metadata, MetadataEntry  # To store and serialize metadata.
+from .unit_conversions import (  # To convert to Blender's units.
+    blender_to_metre,
+    threemf_to_metre,
+)
+
+
 
 log = logging.getLogger(__name__)
 
-ResourceObject = collections.namedtuple("ResourceObject", [
-    "vertices",
-    "triangles",
-    "materials",
-    "components",
-    "metadata"])
+ResourceObject = collections.namedtuple(
+    "ResourceObject", ["vertices", "triangles", "materials", "components", "metadata"]
+)
 Component = collections.namedtuple("Component", ["resource_object", "transformation"])
 ResourceMaterial = collections.namedtuple("ResourceMaterial", ["name", "color"])
 
@@ -51,14 +66,18 @@ class Import3MF(bpy.types.Operator, bpy_extras.io_utils.ImportHelper):
     bl_idname = "import_mesh.threemf"
     bl_label = "Import 3MF"
     bl_description = "Load a 3MF scene"
-    bl_options = {'UNDO'}
+    bl_options = {"UNDO"}
     filename_ext = ".3mf"
 
     # Options for the user.
-    filter_glob: bpy.props.StringProperty(default="*.3mf", options={'HIDDEN'})
-    files: bpy.props.CollectionProperty(name="File Path", type=bpy.types.OperatorFileListElement)
-    directory: bpy.props.StringProperty(subtype='DIR_PATH')
-    global_scale: bpy.props.FloatProperty(name="Scale", default=1.0, soft_min=0.001, soft_max=1000.0, min=1e-6, max=1e6)
+    filter_glob: bpy.props.StringProperty(default="*.3mf", options={"HIDDEN"})
+    files: bpy.props.CollectionProperty(
+        name="File Path", type=bpy.types.OperatorFileListElement
+    )
+    directory: bpy.props.StringProperty(subtype="DIR_PATH")
+    global_scale: bpy.props.FloatProperty(
+        name="Scale", default=1.0, soft_min=0.001, soft_max=1000.0, min=1e-6, max=1e6
+    )
 
     def __init__(self):
         """
@@ -103,12 +122,16 @@ class Import3MF(bpy.types.Operator, bpy_extras.io_utils.ImportHelper):
             paths.append(self.filepath)
 
         if bpy.ops.object.mode_set.poll():
-            bpy.ops.object.mode_set(mode='OBJECT')  # Switch to object mode to view the new file.
+            bpy.ops.object.mode_set(
+                mode="OBJECT"
+            )  # Switch to object mode to view the new file.
         if bpy.ops.object.select_all.poll():
-            bpy.ops.object.select_all(action='DESELECT')  # Deselect other files.
+            bpy.ops.object.select_all(action="DESELECT")  # Deselect other files.
 
         for path in paths:
-            files_by_content_type = self.read_archive(path)  # Get the files from the archive.
+            files_by_content_type = self.read_archive(
+                path
+            )  # Get the files from the archive.
 
             # File metadata.
             for rels_file in files_by_content_type.get(RELS_MIMETYPE, []):
@@ -146,25 +169,31 @@ class Import3MF(bpy.types.Operator, bpy_extras.io_utils.ImportHelper):
 
         # Zoom the camera to view the imported objects.
         for area in bpy.context.screen.areas:
-            if area.type == 'VIEW_3D':
+            if area.type == "VIEW_3D":
                 for region in area.regions:
-                    if region.type == 'WINDOW':
+                    if region.type == "WINDOW":
                         try:
                             # Since Blender 3.2:
                             context = bpy.context.copy()
-                            context['area'] = area
-                            context['region'] = region
-                            context['edit_object'] = bpy.context.edit_object
+                            context["area"] = area
+                            context["region"] = region
+                            context["edit_object"] = bpy.context.edit_object
                             with bpy.context.temp_override(**context):
                                 bpy.ops.view3d.view_selected()
-                        except AttributeError:  # temp_override doesn't exist before Blender 3.2.
+                        except (
+                            AttributeError
+                        ):  # temp_override doesn't exist before Blender 3.2.
                             # Before Blender 3.2:
-                            override = {'area': area, 'region': region, 'edit_object': bpy.context.edit_object}
+                            override = {
+                                "area": area,
+                                "region": region,
+                                "edit_object": bpy.context.edit_object,
+                            }
                             bpy.ops.view3d.view_selected(override)
 
         log.info(f"Imported {self.num_loaded} objects from 3MF files.")
 
-        return {'FINISHED'}
+        return {"FINISHED"}
 
     # The rest of the functions are in order of when they are called.
 
@@ -209,7 +238,9 @@ class Import3MF(bpy.types.Operator, bpy_extras.io_utils.ImportHelper):
         :return: A list of tuples, in order of importance, where the first element describes a regex of paths that
         match, and the second element is the MIME type string of the content type.
         """
-        namespaces = {"ct": "http://schemas.openxmlformats.org/package/2006/content-types"}
+        namespaces = {
+            "ct": "http://schemas.openxmlformats.org/package/2006/content-types"
+        }
         result = []
 
         try:
@@ -219,23 +250,40 @@ class Import3MF(bpy.types.Operator, bpy_extras.io_utils.ImportHelper):
                 except xml.etree.ElementTree.ParseError as e:
                     log.warning(
                         f"{CONTENT_TYPES_LOCATION} has malformed XML"
-                        f"(position {e.position[0]}:{e.position[1]}).")
+                        f"(position {e.position[0]}:{e.position[1]})."
+                    )
                     root = None
 
                 if root is not None:
                     # Overrides are more important than defaults, so put those in front.
                     for override_node in root.iterfind("ct:Override", namespaces):
-                        if "PartName" not in override_node.attrib or "ContentType" not in override_node.attrib:
-                            log.warning("[Content_Types].xml malformed: Override node without path or MIME type.")
+                        if (
+                            "PartName" not in override_node.attrib
+                            or "ContentType" not in override_node.attrib
+                        ):
+                            log.warning(
+                                "[Content_Types].xml malformed: Override node without path or MIME type."
+                            )
                             continue  # Ignore the broken one.
-                        match_regex = re.compile(re.escape(override_node.attrib["PartName"]))
-                        result.append((match_regex, override_node.attrib["ContentType"]))
+                        match_regex = re.compile(
+                            re.escape(override_node.attrib["PartName"])
+                        )
+                        result.append(
+                            (match_regex, override_node.attrib["ContentType"])
+                        )
 
                     for default_node in root.iterfind("ct:Default", namespaces):
-                        if "Extension" not in default_node.attrib or "ContentType" not in default_node.attrib:
-                            log.warning("[Content_Types].xml malformed: Default node without extension or MIME type.")
+                        if (
+                            "Extension" not in default_node.attrib
+                            or "ContentType" not in default_node.attrib
+                        ):
+                            log.warning(
+                                "[Content_Types].xml malformed: Default node without extension or MIME type."
+                            )
                             continue  # Ignore the broken one.
-                        match_regex = re.compile(r".*\." + re.escape(default_node.attrib["Extension"]))
+                        match_regex = re.compile(
+                            r".*\." + re.escape(default_node.attrib["Extension"])
+                        )
                         result.append((match_regex, default_node.attrib["ContentType"]))
         except KeyError:  # ZipFile reports that the content types file doesn't exist.
             log.warning(f"{CONTENT_TYPES_LOCATION} file missing!")
@@ -289,17 +337,22 @@ class Import3MF(bpy.types.Operator, bpy_extras.io_utils.ImportHelper):
         sort that out.
         :param annotations: Collection of annotations gathered so far.
         """
-        preserved_files = set()  # Find all files which must be preserved according to the annotations.
+        preserved_files = (
+            set()
+        )  # Find all files which must be preserved according to the annotations.
         for target, its_annotations in annotations.annotations.items():
             for annotation in its_annotations:
                 if type(annotation) is Relationship:
                     if annotation.namespace in {
                         "http://schemas.openxmlformats.org/package/2006/relationships/mustpreserve",
-                        "http://schemas.microsoft.com/3dmanufacturing/2013/01/printticket"
+                        "http://schemas.microsoft.com/3dmanufacturing/2013/01/printticket",
                     }:
                         preserved_files.add(target)
                 elif type(annotation) is ContentType:
-                    if annotation.mime_type == "application/vnd.ms-printing.printticket+xml":
+                    if (
+                        annotation.mime_type
+                        == "application/vnd.ms-printing.printticket+xml"
+                    ):
                         preserved_files.add(target)
 
         for files in files_by_content_type.values():
@@ -307,19 +360,24 @@ class Import3MF(bpy.types.Operator, bpy_extras.io_utils.ImportHelper):
                 if file.name in preserved_files:
                     filename = ".3mf_preserved/" + file.name
                     if filename in bpy.data.texts:
-                        if bpy.data.texts[filename].as_string() == conflicting_mustpreserve_contents:
+                        if (
+                            bpy.data.texts[filename].as_string()
+                            == conflicting_mustpreserve_contents
+                        ):
                             # This file was previously already in conflict. The new file will always be in conflict with
                             # one of the previous files.
                             continue
                     # Encode as Base85 so that the file can be saved in Blender's Text objects.
-                    file_contents = base64.b85encode(file.read()).decode('UTF-8')
+                    file_contents = base64.b85encode(file.read()).decode("UTF-8")
                     if filename in bpy.data.texts:
                         if bpy.data.texts[filename].as_string() == file_contents:
                             # File contents are EXACTLY the same, so the file is not in conflict.
                             continue  # But we also don't need to re-add the same file then.
                         else:  # Same file exists with different contents, so they are in conflict.
                             bpy.data.texts[filename].clear()
-                            bpy.data.texts[filename].write(conflicting_mustpreserve_contents)
+                            bpy.data.texts[filename].write(
+                                conflicting_mustpreserve_contents
+                            )
                             continue
                     else:  # File doesn't exist yet.
                         handle = bpy.data.texts.new(filename)
@@ -348,7 +406,9 @@ class Import3MF(bpy.types.Operator, bpy_extras.io_utils.ImportHelper):
         scale = self.global_scale
 
         if context.scene.unit_settings.scale_length != 0:
-            scale /= context.scene.unit_settings.scale_length  # Apply the global scale of the units in Blender.
+            scale /= (
+                context.scene.unit_settings.scale_length
+            )  # Apply the global scale of the units in Blender.
 
         threemf_unit = root.attrib.get("unit", MODEL_DEFAULT_UNIT)
         blender_unit = context.scene.unit_settings.length_unit
@@ -384,7 +444,9 @@ class Import3MF(bpy.types.Operator, bpy_extras.io_utils.ImportHelper):
             value = metadata_node.text
 
             # Always store all metadata so that they are preserved.
-            metadata[name] = MetadataEntry(name=name, preserve=preserve, datatype=datatype, value=value)
+            metadata[name] = MetadataEntry(
+                name=name, preserve=preserve, datatype=datatype, value=value
+            )
 
         return metadata
 
@@ -395,7 +457,9 @@ class Import3MF(bpy.types.Operator, bpy_extras.io_utils.ImportHelper):
         The materials will be stored in `self.resource_materials` until it gets used to build the items.
         :param root: The root of an XML document that may contain materials.
         """
-        for basematerials_item in root.iterfind("./3mf:resources/3mf:basematerials", MODEL_NAMESPACES):
+        for basematerials_item in root.iterfind(
+            "./3mf:resources/3mf:basematerials", MODEL_NAMESPACES
+        ):
             try:
                 material_id = basematerials_item.attrib["id"]
             except KeyError:
@@ -410,12 +474,16 @@ class Import3MF(bpy.types.Operator, bpy_extras.io_utils.ImportHelper):
             index = 0
 
             # "Base" must be the stupidest name for a material resource. Oh well.
-            for base_item in basematerials_item.iterfind("./3mf:base", MODEL_NAMESPACES):
+            for base_item in basematerials_item.iterfind(
+                "./3mf:base", MODEL_NAMESPACES
+            ):
                 name = base_item.attrib.get("name", "3MF Material")
                 color = base_item.attrib.get("displaycolor")
                 if color is not None:
                     # Parse the color. It's a hexadecimal number indicating RGB or RGBA.
-                    color = color.lstrip("#")  # Should start with a #. We'll be lenient if it's not.
+                    color = color.lstrip(
+                        "#"
+                    )  # Should start with a #. We'll be lenient if it's not.
                     try:
                         color_int = int(color, 16)
                         # Separate out up to four bytes from this int, from right to left.
@@ -424,19 +492,35 @@ class Import3MF(bpy.types.Operator, bpy_extras.io_utils.ImportHelper):
                         b3 = ((color_int & 0x00FF0000) >> 16) / 255
                         b4 = ((color_int & 0xFF000000) >> 24) / 255
                         if len(color) == 6:  # RGB format.
-                            color = (b3, b2, b1, 1.0)  # b1, b2 and b3 are B, G, R respectively. b4 is always 0.
+                            color = (
+                                b3,
+                                b2,
+                                b1,
+                                1.0,
+                            )  # b1, b2 and b3 are B, G, R respectively. b4 is always 0.
                         else:  # RGBA format, or invalid.
-                            color = (b4, b3, b2, b1)  # b1, b2, b3 and b4 are A, B, G, R respectively.
+                            color = (
+                                b4,
+                                b3,
+                                b2,
+                                b1,
+                            )  # b1, b2, b3 and b4 are A, B, G, R respectively.
                     except ValueError:
-                        log.warning(f"Invalid color for material {name} of resource {material_id}: {color}")
+                        log.warning(
+                            f"Invalid color for material {name} of resource {material_id}: {color}"
+                        )
                         color = None  # Don't add a color for this material.
 
                 # Input is valid. Create a resource.
-                self.resource_materials[material_id][index] = ResourceMaterial(name=name, color=color)
+                self.resource_materials[material_id][index] = ResourceMaterial(
+                    name=name, color=color
+                )
                 index += 1
 
             if len(self.resource_materials[material_id]) == 0:
-                del self.resource_materials[material_id]  # Don't leave empty material sets hanging.
+                del self.resource_materials[
+                    material_id
+                ]  # Don't leave empty material sets hanging.
 
     def read_objects(self, root):
         """
@@ -445,7 +529,9 @@ class Import3MF(bpy.types.Operator, bpy_extras.io_utils.ImportHelper):
         This stores them in the resource_objects field.
         :param root: The root node of a 3dmodel.model XML file.
         """
-        for object_node in root.iterfind("./3mf:resources/3mf:object", MODEL_NAMESPACES):
+        for object_node in root.iterfind(
+            "./3mf:resources/3mf:object", MODEL_NAMESPACES
+        ):
             try:
                 objectid = object_node.attrib["id"]
             except KeyError:
@@ -453,7 +539,9 @@ class Import3MF(bpy.types.Operator, bpy_extras.io_utils.ImportHelper):
                 continue  # ID is required, otherwise the build can't refer to it.
 
             pid = object_node.attrib.get("pid")  # Material ID.
-            pindex = object_node.attrib.get("pindex")  # Index within a collection of materials.
+            pindex = object_node.attrib.get(
+                "pindex"
+            )  # Index within a collection of materials.
             material = None
             if pid is not None and pindex is not None:
                 try:
@@ -462,15 +550,20 @@ class Import3MF(bpy.types.Operator, bpy_extras.io_utils.ImportHelper):
                 except KeyError:
                     log.warning(
                         f"Object with ID {objectid} refers to material collection {pid} with index {pindex}"
-                        f" which doesn't exist.")
+                        f" which doesn't exist."
+                    )
                 except ValueError:
-                    log.warning(f"Object with ID {objectid} specifies material index {pindex}, which is not integer.")
+                    log.warning(
+                        f"Object with ID {objectid} specifies material index {pindex}, which is not integer."
+                    )
 
             vertices = self.read_vertices(object_node)
             triangles, materials = self.read_triangles(object_node, material, pid)
             components = self.read_components(object_node)
             metadata = Metadata()
-            for metadata_node in object_node.iterfind("./3mf:metadatagroup", MODEL_NAMESPACES):
+            for metadata_node in object_node.iterfind(
+                "./3mf:metadatagroup", MODEL_NAMESPACES
+            ):
                 metadata = self.read_metadata(metadata_node, metadata)
             if "partnumber" in object_node.attrib:
                 # Blender has no way to ensure that custom properties get preserved if a mesh is split up, but for most
@@ -479,19 +572,22 @@ class Import3MF(bpy.types.Operator, bpy_extras.io_utils.ImportHelper):
                     name="3mf:partnumber",
                     preserve=True,
                     datatype="xs:string",
-                    value=object_node.attrib["partnumber"])
+                    value=object_node.attrib["partnumber"],
+                )
             metadata["3mf:object_type"] = MetadataEntry(
                 name="3mf:object_type",
                 preserve=True,
                 datatype="xs:string",
-                value=object_node.attrib.get("type", "model"))
+                value=object_node.attrib.get("type", "model"),
+            )
 
             self.resource_objects[objectid] = ResourceObject(
                 vertices=vertices,
                 triangles=triangles,
                 materials=materials,
                 components=components,
-                metadata=metadata)
+                metadata=metadata,
+            )
 
     def read_vertices(self, object_node):
         """
@@ -503,7 +599,9 @@ class Import3MF(bpy.types.Operator, bpy_extras.io_utils.ImportHelper):
         :return: List of vertices in that object. Each vertex is a tuple of 3 floats for X, Y and Z.
         """
         result = []
-        for vertex in object_node.iterfind("./3mf:mesh/3mf:vertices/3mf:vertex", MODEL_NAMESPACES):
+        for vertex in object_node.iterfind(
+            "./3mf:mesh/3mf:vertices/3mf:vertex", MODEL_NAMESPACES
+        ):
             attrib = vertex.attrib
             try:
                 x = float(attrib.get("x", 0))
@@ -539,7 +637,9 @@ class Import3MF(bpy.types.Operator, bpy_extras.io_utils.ImportHelper):
         """
         vertices = []
         materials = []
-        for triangle in object_node.iterfind("./3mf:mesh/3mf:triangles/3mf:triangle", MODEL_NAMESPACES):
+        for triangle in object_node.iterfind(
+            "./3mf:mesh/3mf:triangles/3mf:triangle", MODEL_NAMESPACES
+        ):
             attrib = triangle.attrib
             try:
                 v1 = int(attrib["v1"])
@@ -584,12 +684,16 @@ class Import3MF(bpy.types.Operator, bpy_extras.io_utils.ImportHelper):
         :return: List of components in this object node.
         """
         result = []
-        for component_node in object_node.iterfind("./3mf:components/3mf:component", MODEL_NAMESPACES):
+        for component_node in object_node.iterfind(
+            "./3mf:components/3mf:component", MODEL_NAMESPACES
+        ):
             try:
                 objectid = component_node.attrib["objectid"]
             except KeyError:  # ID is required.
                 continue  # Ignore this invalid component.
-            transform = self.parse_transformation(component_node.attrib.get("transform", ""))
+            transform = self.parse_transformation(
+                component_node.attrib.get("transform", "")
+            )
 
             result.append(Component(resource_object=objectid, transformation=transform))
         return result
@@ -615,7 +719,9 @@ class Import3MF(bpy.types.Operator, bpy_extras.io_utils.ImportHelper):
         """
         components = transformation_str.split(" ")
         result = mathutils.Matrix.Identity(4)
-        if transformation_str == "":  # Early-out if transformation is missing. This is not malformed.
+        if (
+            transformation_str == ""
+        ):  # Early-out if transformation is missing. This is not malformed.
             return result
         row = -1
         col = 0
@@ -625,7 +731,9 @@ class Import3MF(bpy.types.Operator, bpy_extras.io_utils.ImportHelper):
                 col += 1
                 row = 0
                 if col > 3:
-                    log.warning(f"Transformation matrix contains too many components: {transformation_str}")
+                    log.warning(
+                        f"Transformation matrix contains too many components: {transformation_str}"
+                    )
                     break  # Too many components. Ignore the rest.
             try:
                 component_float = float(component)
@@ -649,26 +757,40 @@ class Import3MF(bpy.types.Operator, bpy_extras.io_utils.ImportHelper):
             try:
                 objectid = build_item.attrib["objectid"]
                 resource_object = self.resource_objects[objectid]
-            except KeyError:  # ID is required, and it must be in the available resource_objects.
+            except (
+                KeyError
+            ):  # ID is required, and it must be in the available resource_objects.
                 log.warning("Encountered build item without object ID.")
                 continue  # Ignore this invalid item.
 
             metadata = Metadata()
-            for metadata_node in build_item.iterfind("./3mf:metadatagroup", MODEL_NAMESPACES):
+            for metadata_node in build_item.iterfind(
+                "./3mf:metadatagroup", MODEL_NAMESPACES
+            ):
                 metadata = self.read_metadata(metadata_node, metadata)
             if "partnumber" in build_item.attrib:
                 metadata["3mf:partnumber"] = MetadataEntry(
                     name="3mf:partnumber",
                     preserve=True,
                     datatype="xs:string",
-                    value=build_item.attrib["partnumber"])
+                    value=build_item.attrib["partnumber"],
+                )
 
             transform = mathutils.Matrix.Scale(scale_unit, 4)
-            transform @= self.parse_transformation(build_item.attrib.get("transform", ""))
+            transform @= self.parse_transformation(
+                build_item.attrib.get("transform", "")
+            )
 
             self.build_object(resource_object, transform, metadata, [objectid])
 
-    def build_object(self, resource_object, transformation, metadata, objectid_stack_trace, parent=None):
+    def build_object(
+        self,
+        resource_object,
+        transformation,
+        metadata,
+        objectid_stack_trace,
+        parent=None,
+    ):
         """
         Converts a resource object into a Blender object.
 
@@ -694,7 +816,9 @@ class Import3MF(bpy.types.Operator, bpy_extras.io_utils.ImportHelper):
 
             # Mapping resource materials to indices in the list of materials for this specific mesh.
             materials_to_index = {}
-            for triangle_index, triangle_material in enumerate(resource_object.materials):
+            for triangle_index, triangle_material in enumerate(
+                resource_object.materials
+            ):
                 if triangle_material is None:
                     continue
 
@@ -702,7 +826,9 @@ class Import3MF(bpy.types.Operator, bpy_extras.io_utils.ImportHelper):
                 if triangle_material not in self.resource_to_material:
                     material = bpy.data.materials.new(triangle_material.name)
                     material.use_nodes = True
-                    principled = bpy_extras.node_shader_utils.PrincipledBSDFWrapper(material, is_readonly=False)
+                    principled = bpy_extras.node_shader_utils.PrincipledBSDFWrapper(
+                        material, is_readonly=False
+                    )
                     principled.base_color = triangle_material.color[:3]
                     principled.alpha = triangle_material.color[3]
                     self.resource_to_material[triangle_material] = material
@@ -713,13 +839,17 @@ class Import3MF(bpy.types.Operator, bpy_extras.io_utils.ImportHelper):
                 if triangle_material not in materials_to_index:
                     new_index = len(mesh.materials.items())
                     if new_index > 32767:
-                        log.warning("Blender doesn't support more than 32768 different materials per mesh.")
+                        log.warning(
+                            "Blender doesn't support more than 32768 different materials per mesh."
+                        )
                         continue
                     mesh.materials.append(material)
                     materials_to_index[triangle_material] = new_index
 
                 # Assign the material to the correct triangle.
-                mesh.polygons[triangle_index].material_index = materials_to_index[triangle_material]
+                mesh.polygons[triangle_index].material_index = materials_to_index[
+                    triangle_material
+                ]
 
         # Create an object.
         blender_object = bpy.data.objects.new("3MF Object", mesh)
@@ -731,8 +861,9 @@ class Import3MF(bpy.types.Operator, bpy_extras.io_utils.ImportHelper):
         bpy.context.view_layer.objects.active = blender_object
         blender_object.select_set(True)
         metadata.store(blender_object)
-        if "3mf:object_type" in resource_object.metadata\
-                and resource_object.metadata["3mf:object_type"].value in {"solidsupport", "support"}:
+        if "3mf:object_type" in resource_object.metadata and resource_object.metadata[
+            "3mf:object_type"
+        ].value in {"solidsupport", "support"}:
             # Don't render support meshes.
             blender_object.hide_render = True
 
@@ -740,14 +871,26 @@ class Import3MF(bpy.types.Operator, bpy_extras.io_utils.ImportHelper):
         for component in resource_object.components:
             if component.resource_object in objectid_stack_trace:
                 # These object IDs refer to each other in a loop. Don't go in there!
-                log.warning(f"Recursive components in object ID: {component.resource_object}")
+                log.warning(
+                    f"Recursive components in object ID: {component.resource_object}"
+                )
                 continue
             try:
                 child_object = self.resource_objects[component.resource_object]
             except KeyError:  # Invalid resource ID. Doesn't exist!
-                log.warning(f"Build item with unknown resource ID: {component.resource_object}")
+                log.warning(
+                    f"Build item with unknown resource ID: {component.resource_object}"
+                )
                 continue
-            transform = transformation @ component.transformation  # Apply the child's transformation and pass it on.
+            transform = (
+                transformation @ component.transformation
+            )  # Apply the child's transformation and pass it on.
             objectid_stack_trace.append(component.resource_object)
-            self.build_object(child_object, transform, metadata, objectid_stack_trace, parent=blender_object)
+            self.build_object(
+                child_object,
+                transform,
+                metadata,
+                objectid_stack_trace,
+                parent=blender_object,
+            )
             objectid_stack_trace.pop()

--- a/io_mesh_3mf/metadata.py
+++ b/io_mesh_3mf/metadata.py
@@ -1,5 +1,7 @@
+
 # Blender add-on to import and export 3MF files.
 # Copyright (C) 2020 Ghostkeeper
+# Copyright (C) 2025 Jack (modernization for Blender 4.2+)
 # This add-on is free software; you can redistribute it and/or modify it under the terms of the GNU General Public
 # License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later
 # version.
@@ -11,9 +13,12 @@
 # <pep8 compliant>
 
 import collections  # For named tuples.
+
 import idprop.types  # To interpret property groups as metadata entries.
 
-MetadataEntry = collections.namedtuple("MetadataEntry", ["name", "preserve", "datatype", "value"])
+MetadataEntry = collections.namedtuple(
+    "MetadataEntry", ["name", "preserve", "datatype", "value"]
+)
 
 
 class Metadata:
@@ -66,12 +71,15 @@ class Metadata:
 
         # The two are consistent. Usually no need to store anything, since it's already stored.
         # The "preserve" property may be different. Preserve if any of them says to preserve.
-        if not competing.preserve and value.preserve:  # Prevent unnecessary construction of namedtuples.
+        if (
+            not competing.preserve and value.preserve
+        ):  # Prevent unnecessary construction of namedtuples.
             self.metadata[key] = MetadataEntry(
                 name=key,
                 preserve=True,
                 datatype=competing.datatype,
-                value=competing.value)
+                value=competing.value,
+            )
 
     def __getitem__(self, key):
         """
@@ -147,7 +155,9 @@ class Metadata:
         for metadata_entry in self.values():
             name = metadata_entry.name
             value = metadata_entry.value
-            if name == "Title":  # Has a built-in ID property for objects as well as scenes.
+            if (
+                name == "Title"
+            ):  # Has a built-in ID property for objects as well as scenes.
                 blender_object.name = value if value is not None else ""
             elif name == "3mf:partnumber":
                 # Special case: This is always a string and doesn't need the preserve attribute. We can simplify this to
@@ -173,21 +183,28 @@ class Metadata:
         for key in blender_object.keys():
             entry = blender_object[key]
             if key == "3mf:partnumber":
-                self[key] = MetadataEntry(name=key, preserve=True, datatype="xs:string", value=entry)
+                self[key] = MetadataEntry(
+                    name=key, preserve=True, datatype="xs:string", value=entry
+                )
                 continue
-            if isinstance(entry, idprop.types.IDPropertyGroup)\
-                    and "datatype" in entry.keys()\
-                    and "preserve" in entry.keys()\
-                    and "value" in entry.keys():  # Most likely a metadata entry from a previous 3MF file.
+            if (
+                isinstance(entry, idprop.types.IDPropertyGroup)
+                and "datatype" in entry.keys()
+                and "preserve" in entry.keys()
+                and "value" in entry.keys()
+            ):  # Most likely a metadata entry from a previous 3MF file.
                 self[key] = MetadataEntry(
                     name=key,
                     preserve=entry.get("preserve"),
                     datatype=entry.get("datatype"),
-                    value=entry.get("value"))
+                    value=entry.get("value"),
+                )
             # Don't mess with metadata added by the user or their other Blender add-ons. Don't want to break their
             # behaviour.
 
-        self["Title"] = MetadataEntry(name="Title", preserve=True, datatype="xs:string", value=blender_object.name)
+        self["Title"] = MetadataEntry(
+            name="Title", preserve=True, datatype="xs:string", value=blender_object.name
+        )
 
     def values(self):
         """

--- a/io_mesh_3mf/unit_conversions.py
+++ b/io_mesh_3mf/unit_conversions.py
@@ -1,5 +1,6 @@
 # Blender add-on to import and export 3MF files.
 # Copyright (C) 2020 Ghostkeeper
+# Copyright (C) 2025 Jack (modernization for Blender 4.2+)
 # This add-on is free software; you can redistribute it and/or modify it under the terms of the GNU General Public
 # License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later
 # version.
@@ -8,36 +9,35 @@
 # You should have received a copy of the GNU General Public License along with this program; if not, write to the Free
 # Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-# <pep8 compliant>
 
 """
 This file defines unit conversions between Blender's units and 3MF's units.
 """
 
 blender_to_metre = {  # Scale of each of Blender's length units to a metre.
-    'THOU': 0.0000254,
-    'INCHES': 0.0254,
-    'FEET': 0.3048,
-    'YARDS': 0.9144,
-    'CHAINS': 20.1168,
-    'FURLONGS': 201.168,
-    'MILES': 1609.344,
-    'MICROMETERS': 0.000001,
-    'MILLIMETERS': 0.001,
-    'CENTIMETERS': 0.01,
-    'DECIMETERS': 0.1,
-    'METERS': 1,
-    'ADAPTIVE': 1,
-    'DEKAMETERS': 10,
-    'HECTOMETERS': 100,
-    'KILOMETERS': 1000
+    "THOU": 0.0000254,
+    "INCHES": 0.0254,
+    "FEET": 0.3048,
+    "YARDS": 0.9144,
+    "CHAINS": 20.1168,
+    "FURLONGS": 201.168,
+    "MILES": 1609.344,
+    "MICROMETERS": 0.000001,
+    "MILLIMETERS": 0.001,
+    "CENTIMETERS": 0.01,
+    "DECIMETERS": 0.1,
+    "METERS": 1,
+    "ADAPTIVE": 1,
+    "DEKAMETERS": 10,
+    "HECTOMETERS": 100,
+    "KILOMETERS": 1000,
 }
 
 threemf_to_metre = {  # Scale of each of 3MF's length units to a metre.
-    'micron': 0.000001,
-    'millimeter': 0.001,
-    'centimeter': 0.01,
-    'inch': 0.0254,
-    'foot': 0.3048,
-    'meter': 1
+    "micron": 0.000001,
+    "millimeter": 0.001,
+    "centimeter": 0.01,
+    "inch": 0.0254,
+    "foot": 0.3048,
+    "meter": 1,
 }


### PR DESCRIPTION
This pull request begins the modernization of the Blender 3MF Format addon to restore compatibility with Blender 4.2+ and improve code quality. The changes introduce a modernization checklist, update documentation to reflect ongoing work, and start refactoring the codebase for better maintainability and compliance with new Blender and Python standards.

**Documentation and Project Management Updates:**

* Added a comprehensive modernization checklist in `MODERNIZATION_CHECKLIST.md`, outlining critical fixes, API updates, testing plans, code quality improvements, CI/CD setup, and known issues for Blender 4.2+ compatibility.
* Updated `README.md` to include a modernization notice, clarify version guidance, credit contributors, and document the current status of the modernization effort.

**Licensing and Attribution:**

* Added copyright and modernization attribution for 2025 to `io_mesh_3mf/__init__.py` and `io_mesh_3mf/annotations.py`, crediting Jack for the Blender 4.2+ updates. [[1]](diffhunk://#diff-cc1944c62dac3b93f34f83e9f1815315dc804b8ef58282b882cc35a6aa023e3aR3) [[2]](diffhunk://#diff-dc0d6d068b668e0b01724e989f44321efc5ca3884c91dd0f6b59c3df70a96c33R3)

**Codebase Modernization and Refactoring:**

* Replaced wildcard imports with explicit imports in `io_mesh_3mf/annotations.py` to improve code clarity and linter compliance.
* Refactored reload logic and streamlined imports in `io_mesh_3mf/__init__.py` for better module management and Blender 4.2+ compatibility. [[1]](diffhunk://#diff-cc1944c62dac3b93f34f83e9f1815315dc804b8ef58282b882cc35a6aa023e3aL11-R30) [[2]](diffhunk://#diff-cc1944c62dac3b93f34f83e9f1815315dc804b8ef58282b882cc35a6aa023e3aL56-R47)
* Improved formatting, line breaks, and readability in `io_mesh_3mf/annotations.py`, including more robust logging and clearer annotation handling. [[1]](diffhunk://#diff-dc0d6d068b668e0b01724e989f44321efc5ca3884c91dd0f6b59c3df70a96c33L31-R44) [[2]](diffhunk://#diff-dc0d6d068b668e0b01724e989f44321efc5ca3884c91dd0f6b59c3df70a96c33L79-R93) [[3]](diffhunk://#diff-dc0d6d068b668e0b01724e989f44321efc5ca3884c91dd0f6b59c3df70a96c33L89-R105) [[4]](diffhunk://#diff-dc0d6d068b668e0b01724e989f44321efc5ca3884c91dd0f6b59c3df70a96c33L104-R122) [[5]](diffhunk://#diff-dc0d6d068b668e0b01724e989f44321efc5ca3884c91dd0f6b59c3df70a96c33L129-R161)